### PR TITLE
Add the aspell engine as an option for roundcube

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -12,6 +12,10 @@ class roundcube::params {
   $roundcube_webserver        = 'apache'
   $ip_mask_allow_all_users    = '0.0.0.0/0'
 
+  #spellchecker params
+  $spellcheck_engine          = 'googie'
+  $spellcheck_languages       = []
+
   #webserver params
   $apt_mirror                 = 'http://ftp.debian.org/debian'
   $main_inc_php_erb           = 'roundcube/main.inc.php.erb'

--- a/manifests/roundcubeweb.pp
+++ b/manifests/roundcubeweb.pp
@@ -12,9 +12,17 @@ class roundcube::roundcubeweb (
   $database_ssl              = $roundcube::params::database_ssl,
   $listen_addresses          = $roundcube::params::postgres_listen_address,
   $main_inc_php_erb          = $roundcube::params::main_inc_php_erb,
+  $spellcheck_engine         = $roundcube::params::spellcheck_engine,
+  $spellcheck_languages      = $roundcube::params::spellcheck_languages
   ) inherits roundcube::params {
 
   $packagelist = ['roundcube', 'roundcube-core', 'roundcube-plugins']
+
+  if $spellcheck_engine == 'aspell' {
+    class { '::roundcube::spellchecker::aspell':
+       languagelist => $spellcheck_languages
+    }
+  }
 
   apt::source { 'wheezy-backports':
     location => $apt_mirror,

--- a/manifests/spellchecker/aspell.pp
+++ b/manifests/spellchecker/aspell.pp
@@ -1,0 +1,13 @@
+class roundcube::spellchecker::aspell (
+    $languagelist = ['en']
+  ) {
+
+  $langlist = prefix($languagelist, 'aspell-')
+
+  $packagelist = concat(['aspell', 'php5-enchant'], $langlist)
+
+  package { $packagelist:
+    ensure  => installed,
+  }
+
+}

--- a/templates/main.inc.php.erb
+++ b/templates/main.inc.php.erb
@@ -495,7 +495,7 @@ $rcmail_config['spellcheck_dictionary'] = false;
 
 // Set the spell checking engine. 'googie' is the default. 'pspell' is also available,
 // but requires the Pspell extensions. When using Nox Spell Server, also set 'googie' here.
-$rcmail_config['spellcheck_engine'] = 'googie';
+$rcmail_config['spellcheck_engine'] = '<%= @spellcheck_engine %>';
 
 // For a locally installed Nox Spell Server, please specify the URI to call it.
 // Get Nox Spell Server from http://orangoo.com/labs/?page_id=72
@@ -506,7 +506,7 @@ $rcmail_config['spellcheck_uri'] = '';
 // These languages can be selected for spell checking.
 // Configure as a PHP style hash array: array('en'=>'English', 'de'=>'Deutsch');
 // Leave empty for default set of available language.
-$rcmail_config['spellcheck_languages'] = NULL;
+$rcmail_config['spellcheck_languages'] = array('<%= @spellcheck_languages.join("\',\'") %>');
 
 // Makes that words with all letters capitalized will be ignored (e.g. GOOGLE)
 $rcmail_config['spellcheck_ignore_caps'] = false;


### PR DESCRIPTION
* The default spellchecker uses google for spell checking
* Aspell via enchant is now available as an option
* Multiple languages can be specified in an array which will also install the aspell package for each
* The default empty value for languages uses the defaults