### PR TITLE
full path required for exec commands with puppet 3.7

### DIFF
--- a/manifests/roundcubeweb.pp
+++ b/manifests/roundcubeweb.pp
@@ -93,7 +93,7 @@ class roundcube::roundcubeweb (
 
   exec { 'reconfigure_roundcube':
     refreshonly => true,
-    command     => 'dpkg-reconfigure roundcube-core',
+    command     => '/usr/sbin/dpkg-reconfigure roundcube-core',
   }
 
   file { "${confdir}/main.inc.php":


### PR DESCRIPTION
puppet fails if full path is not specified

perhaps this should be parameterised also?